### PR TITLE
Support Ruby 3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,8 @@ Style/ParenthesesAroundCondition:
 AllCops:
   TargetRubyVersion: 2.6
   NewCops: enable
+  Exclude:
+    - template/**/*
 
 Metrics/BlockLength:
   Exclude:

--- a/flame-cli.gemspec
+++ b/flame-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 		'wiki_uri' => 'https://github.com/AlexWayfer/flame-cli/wiki'
 	}
 
-	spec.required_ruby_version = '>= 2.6'
+	spec.required_ruby_version = '>= 2.6', '< 4'
 
 	spec.add_runtime_dependency 'clamp', '~> 1.3'
 	spec.add_runtime_dependency 'gorilla_patch', '~> 4.0'

--- a/template/Gemfile
+++ b/template/Gemfile
@@ -46,7 +46,7 @@ end
 
 group :translations do
 	gem 'flame-r18n', github: 'AlexWayfer/flame-r18n'
-	gem 'r18n-core', github: 'r18n/r18n'
+	gem 'r18n-core'
 end
 
 group :forms do

--- a/template/spec/spec_helper.rb
+++ b/template/spec/spec_helper.rb
@@ -4,7 +4,7 @@ ENV['RACK_ENV'] ||= 'test'
 
 require 'pry-byebug'
 
-Dir["#{__dir__}/**/spec_helper.rb"].sort.each do |spec_helper|
+Dir["#{__dir__}/**/spec_helper.rb"].each do |spec_helper|
 	next if spec_helper == __FILE__
 
 	require spec_helper


### PR DESCRIPTION
1.  Avoid Ruby 4 in gem specs.
2.  Update `r18n-core` to actual version, supporting Ruby 3.
3.  Remove redundant `sort` for `Dir` globbing.
4.  Exclude `template/` for root RuboCop.
    There is conflict between required `sort` for target Ruby 2.6 of gem itself
    and target Ruby 3 from `.ruby-version` generated from template.